### PR TITLE
Postgres refused connection fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
-POSTGRES_USER=blueprint_admin_backend
+POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=postgres
 SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/postgres
-SPRING_DATASOURCE_USERNAME=blueprint_admin_backend
+SPRING_DATASOURCE_USERNAME=postgres
 SPRING_DATASOURCE_PASSWORD=postgres
 SPRING_PROFILES_ACTIVE=dev

--- a/README.md
+++ b/README.md
@@ -19,11 +19,17 @@ You should see the following output in your terminal
 ```
 o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http) with context path ''
 com.sitblueprint.admin.BlueprintAdmin    : Started BlueprintAdmin in 2.255 seconds (process running for 2.392)
-
 ```
 
 You can also run the server directly from the terminal
 
+## Troubleshooting
+If you are having issues running the postgres db with Docker try the following
+```bash
+docker-compose down -v
+rm -rf postgres-data
+docker-compose up --build
+```
 
 ## How to connect to database in Docker Container?
 Start the docker container

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:10-alpine
     restart: always
     environment:
       - POSTGRES_USER=${POSTGRES_USER}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/postgres}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME:blueprint_admin_backend}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:postgres}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:postgres}
 
 spring.profiles.active=${SPRING_PROFILES_ACTIVE:dev}


### PR DESCRIPTION
## Description
I pinpointed the issues to be the following:
- The `init.sql` script had syntax only supported by `postgres-10`, not `postgres-latest`. This caused the db container to not initialize correctly and reboot
- Once the postgres version was fixed, the db would not bootstrap because the `postgres` role was not defined. This was caused due to the default role being created to be `blueprint_admin`. Thereby, I changed the default name of the postgres role to be `postgres`